### PR TITLE
Make lock container configurable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,10 @@ gemfile:
   - gemfiles/sidekiq_5.gemfile
 
 rvm:
-  - 2.2.9
-  - 2.3.6
-  - 2.4.3
-  - 2.5.0
+  - 2.2.10
+  - 2.3.7
+  - 2.4.4
+  - 2.5.1
 
 notifications:
   email: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.0 (July 18, 2018)
+
+- make lock container configurable (non breaking change) - in case you would like to something else than `Thread.current` - now you easily can
+
 ## 0.3.1 (March 3, 2018)
 
 - do not assume `ActiveSupport` is loaded / or old `Sidekiq` patches are present (add own symbolize keys logic)

--- a/lib/sidekiq/lock.rb
+++ b/lib/sidekiq/lock.rb
@@ -1,11 +1,20 @@
+require 'sidekiq/lock/container'
 require 'sidekiq/lock/middleware'
 require 'sidekiq/lock/redis_lock'
 require 'sidekiq/lock/version'
 require 'sidekiq/lock/worker'
 
 module Sidekiq
+  def self.lock_container
+    @lock_container ||= Lock::Container.new
+  end
+
   def self.lock_method
-    @lock_method ||= :lock
+    @lock_method ||= Lock::METHOD_NAME
+  end
+
+  def self.lock_container=(container)
+    @lock_container = container
   end
 
   def self.lock_method=(method)
@@ -14,6 +23,7 @@ module Sidekiq
 
   module Lock
     THREAD_KEY = :sidekiq_lock
+    METHOD_NAME = :lock
   end
 end
 

--- a/lib/sidekiq/lock/container.rb
+++ b/lib/sidekiq/lock/container.rb
@@ -1,0 +1,15 @@
+module Sidekiq
+  module Lock
+    class Container
+      THREAD_KEY = :sidekiq_lock
+
+      def fetch
+        Thread.current[THREAD_KEY]
+      end
+
+      def store(lock)
+        Thread.current[THREAD_KEY] = lock
+      end
+    end
+  end
+end

--- a/lib/sidekiq/lock/middleware.rb
+++ b/lib/sidekiq/lock/middleware.rb
@@ -1,7 +1,7 @@
 module Sidekiq
   module Lock
     class Middleware
-      def call(worker, msg, queue)
+      def call(worker, msg, _queue)
         options = lock_options(worker)
         setup_lock(options, msg['args']) unless options.nil?
 
@@ -11,7 +11,7 @@ module Sidekiq
       private
 
       def setup_lock(options, payload)
-        Thread.current[Sidekiq::Lock::THREAD_KEY] = RedisLock.new(options, payload)
+        Sidekiq.lock_container.store(RedisLock.new(options, payload))
       end
 
       def lock_options(worker)

--- a/lib/sidekiq/lock/testing/inline.rb
+++ b/lib/sidekiq/lock/testing/inline.rb
@@ -1,8 +1,8 @@
 def set_sidekiq_lock(worker_class, payload)
   options = worker_class.get_sidekiq_options['lock']
-  Thread.current[Sidekiq::Lock::THREAD_KEY] = Sidekiq::Lock::RedisLock.new(options, payload)
+  Sidekiq.lock_container.store(Sidekiq::Lock::RedisLock.new(options, payload))
 end
 
 def clear_sidekiq_lock
-  Thread.current[Sidekiq::Lock::THREAD_KEY] = nil
+  Sidekiq.lock_container.store(nil)
 end

--- a/lib/sidekiq/lock/version.rb
+++ b/lib/sidekiq/lock/version.rb
@@ -1,5 +1,5 @@
 module Sidekiq
   module Lock
-    VERSION = '0.3.1'
+    VERSION = '0.4.0'
   end
 end

--- a/lib/sidekiq/lock/worker.rb
+++ b/lib/sidekiq/lock/worker.rb
@@ -3,7 +3,7 @@ module Sidekiq
     module Worker
       def self.included(base)
         base.send(:define_method, Sidekiq.lock_method) do
-          Thread.current[Sidekiq::Lock::THREAD_KEY]
+          Sidekiq.lock_container.fetch
         end
       end
     end

--- a/test/lib/container_test.rb
+++ b/test/lib/container_test.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+require 'open3'
+
+module Sidekiq
+  module Lock
+    describe Container do
+      it 'stores and fetches given value under Thread.current' do
+        begin
+          container = Sidekiq::Lock::Container.new
+          thread_key = Sidekiq::Lock::Container::THREAD_KEY
+
+          Thread.current[thread_key] = 'value'
+          assert_equal 'value', container.fetch
+
+          container.store 'new-value'
+          assert_equal Thread.current[thread_key], 'new-value'
+        ensure
+          Thread.current[thread_key] = nil
+        end
+      end
+    end
+  end
+end

--- a/test/lib/middleware_test.rb
+++ b/test/lib/middleware_test.rb
@@ -6,36 +6,35 @@ module Sidekiq
       before do
         Sidekiq.redis = REDIS
         Sidekiq.redis { |c| c.flushdb }
-        set_lock_variable!
+        reset_lock_variable!
       end
 
-      let(:handler){ Sidekiq::Lock::Middleware.new }
+      let(:handler) { Sidekiq::Lock::Middleware.new }
 
       it 'sets lock variable with provided static lock options' do
-        handler.call(LockWorker.new, {'class' => LockWorker, 'args' => []}, 'default') do
+        handler.call(LockWorker.new, { 'class' => LockWorker, 'args' => [] }, 'default') do
           true
         end
 
-        assert_kind_of RedisLock, lock_thread_variable
+        assert_kind_of RedisLock, lock_container_variable
       end
 
       it 'sets lock variable with provided dynamic options' do
-        handler.call(DynamicLockWorker.new, {'class' => DynamicLockWorker, 'args' => [1234, 1000]}, 'default') do
+        handler.call(DynamicLockWorker.new, { 'class' => DynamicLockWorker, 'args' => [1234, 1000] }, 'default') do
           true
         end
 
-        assert_equal "lock:1234", lock_thread_variable.name
-        assert_equal 2000,   lock_thread_variable.timeout
+        assert_equal "lock:1234", lock_container_variable.name
+        assert_equal 2000, lock_container_variable.timeout
       end
 
       it 'sets nothing for workers without lock options' do
-        handler.call(RegularWorker.new, {'class' => RegularWorker, 'args' => []}, 'default') do
+        handler.call(RegularWorker.new, { 'class' => RegularWorker, 'args' => [] }, 'default') do
           true
         end
 
-        assert_nil lock_thread_variable
+        assert_nil lock_container_variable
       end
-
     end
   end
 end

--- a/test/lib/testing/inline_test.rb
+++ b/test/lib/testing/inline_test.rb
@@ -2,20 +2,23 @@ require "test_helper"
 require "sidekiq/lock/testing/inline"
 
 describe "inline test helper" do
-  after { set_lock_variable! }
+  after { reset_lock_variable! }
 
   it "has helper fuction for setting lock" do
-    Sidekiq::Lock::RedisLock.expects(:new).with({ timeout: 1, name: 'lock-worker' }, 'worker argument').returns('lock set')
+    Sidekiq::Lock::RedisLock
+      .expects(:new)
+      .with({ timeout: 1, name: 'lock-worker' }, 'worker argument')
+      .returns('lock set')
+
     set_sidekiq_lock(LockWorker, 'worker argument')
-    assert_equal 'lock set', lock_thread_variable
+    assert_equal 'lock set', lock_container_variable
   end
 
   it "has helper fuction for clearing lock" do
     set_lock_variable! "test"
-    assert_equal "test", lock_thread_variable
+    assert_equal "test", lock_container_variable
 
     clear_sidekiq_lock
-    assert_nil lock_thread_variable
+    assert_nil lock_container_variable
   end
-
 end

--- a/test/lib/worker_test.rb
+++ b/test/lib/worker_test.rb
@@ -3,26 +3,64 @@ require 'test_helper'
 module Sidekiq
   module Lock
     describe Worker do
-      after { set_lock_variable! }
+      # after {  }
 
-      it 'sets lock method that points to thread variable' do
-        set_lock_variable! "test"
-        assert_equal "test", LockWorker.new.lock
-      end
-
-      it 'allows method name configuration' do
-        Sidekiq.lock_method = :custom_lock_name
-
-        class WorkerWithCustomLockName
-          include Sidekiq::Worker
-          include Sidekiq::Lock::Worker
+      class CustomContainer
+        def initialize
+          @lock = nil
         end
 
-        set_lock_variable! "custom_name"
+        def fetch
+          @lock
+        end
 
-        assert_equal "custom_name", WorkerWithCustomLockName.new.custom_lock_name
+        def store(lock)
+          @lock = lock
+        end
       end
 
+      # it 'sets lock method that points to thread variable' do
+      #   set_lock_variable! "test"
+      #   assert_equal "test", LockWorker.new.lock
+      # end
+
+      it 'allows method name configuration' do
+        begin
+          Sidekiq.lock_method = :custom_lock_name
+
+          class WorkerWithCustomLockName
+            include Sidekiq::Worker
+            include Sidekiq::Lock::Worker
+          end
+
+          set_lock_variable! "custom_name"
+
+          assert_equal "custom_name", WorkerWithCustomLockName.new.custom_lock_name
+
+          reset_lock_variable!
+        ensure
+
+          Sidekiq.lock_method = Sidekiq::Lock::METHOD_NAME
+        end
+      end
+
+      it 'allows container configuration' do
+        begin
+          container = CustomContainer.new
+          Sidekiq.lock_container = container
+
+          class WorkerWithCustomContainer
+            include Sidekiq::Worker
+            include Sidekiq::Lock::Worker
+          end
+
+          container.store "lock-variable"
+
+          assert_equal "lock-variable", WorkerWithCustomContainer.new.lock
+        ensure
+          Sidekiq.lock_container = Sidekiq::Lock::Container.new
+        end
+      end
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -20,10 +20,14 @@ def redis(command, *args)
   end
 end
 
-def set_lock_variable!(value = nil)
-  Thread.current[Sidekiq::Lock::THREAD_KEY] = value
+def set_lock_variable!(value)
+  Sidekiq.lock_container.store(value)
 end
 
-def lock_thread_variable
-  Thread.current[Sidekiq::Lock::THREAD_KEY]
+def reset_lock_variable!
+  set_lock_variable!(nil)
+end
+
+def lock_container_variable
+  Sidekiq.lock_container.fetch
 end


### PR DESCRIPTION
After seeing fork https://github.com/SolarCS/sidekiq-lock and catching up with some books on design ;) I got inspired to make this small addition - it makes gem more extendable - for whatever reason you might need

One would argue why even bother with defining lock method on worker instance in the first place now - but I don't want to introduce any hardcore backward-incompatible changes

I also got curious @ziolmar - did you encountered some issues when using `Thread.current` while simply spinning few sidekiq processes? What was the use case/scenario? 🤔 Eager to share maybe?